### PR TITLE
A bunch of refactoring and 2 bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Original from andya@apache.org (http://www.hexten.net/sw/mod_log_rotate/index.mh
 
 ## CONFIGURATION DIRECTIVES:
 
-	RotateLogs On|Off   Enable / disable automatic log rotation. Once enabled
+	RotateLogs On|Off   Enable / disable automatic log rotation. If enabled
 						mod_log_rotate takes responsibility for all log output
-						server wide even if RotateLogs Off is subsequently
-						used. That means that the BufferedLogs directive that
-						is implemented by mod_log_config will be ignored.
+						server wide. That means the BufferedLogs directive
+						implemented by mod_log_config will be ignored.
 
 	RotateLogsLocalTime Normally the log rotation interval is based on UTC.
 						For example an interval of 86400 (one day) will cause

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -271,16 +271,15 @@ static apr_status_t ap_rotated_log_writer(request_rec *r, void *handle,
     }
 
     if (NULL != rl->fd) {
-        if (rl->st.enabled) {
-            if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
-                return rv;
-        }
-
         str = apr_palloc(r->pool, len + 1);
-
         for (i = 0, s = str; i < nelts; ++i) {
             memcpy(s, strs[i], strl[i]);
             s += strl[i];
+        }
+
+        if (rl->st.enabled) {
+            if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
+                return rv;
         }
 
         rv = apr_file_write(rl->fd, str, &len);

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -341,6 +341,9 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
 
 static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
     log_options *ls = ap_get_module_config(cmd->server->module_config, &log_rotate_module);
+    APR_OPTIONAL_FN_TYPE(ap_log_set_writer_init) *set_writer_init;
+    APR_OPTIONAL_FN_TYPE(ap_log_set_writer)      *set_writer;
+
     if (flag) {
         /* Always hook the writer functions when we're enabled even if we've
          * done it already. We can't unhook which means that once we've been
@@ -348,9 +351,6 @@ static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
          * a subsequent BufferedLogs On in conf will clobber these hooks and
          * disable us.
          */
-        APR_OPTIONAL_FN_TYPE(ap_log_set_writer_init) *set_writer_init;
-        APR_OPTIONAL_FN_TYPE(ap_log_set_writer)      *set_writer;
-
         set_writer_init = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer_init);
         set_writer      = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer);
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -110,25 +110,23 @@ static apr_file_t *ap_open_log(apr_pool_t *p, server_rec *s, const char *base, l
         return NULL;
     }
 
-    if (ls->enabled) {
-        log_time = tm - ls->offset;
-        if (strchr(base, '%') != NULL) {
-            apr_time_exp_t e;
+    log_time = tm - ls->offset;
+    if (strchr(base, '%') != NULL) {
+        apr_time_exp_t e;
 
-            apr_time_exp_gmt(&e, log_time);
-            name = ap_pstrftime(p, name, &e);
-        }
-        else
-        {
-            /* Synthesize the log name using the specified time in seconds as a
-                * suffix.  We subtract the offset here because it was added when
-                * quantizing the time but we want the name to reflect the actual
-                * time when the log rotated. We don't reverse the local time
-                * adjustment because, presumably, if you've specified local time
-                * logging you want the filenames to use local time.
-                */
-            name = apr_psprintf(p, "%s.%" APR_TIME_T_FMT, name, apr_time_sec(log_time));
-        }
+        apr_time_exp_gmt(&e, log_time);
+        name = ap_pstrftime(p, name, &e);
+    }
+    else
+    {
+        /* Synthesize the log name using the specified time in seconds as a
+            * suffix.  We subtract the offset here because it was added when
+            * quantizing the time but we want the name to reflect the actual
+            * time when the log rotated. We don't reverse the local time
+            * adjustment because, presumably, if you've specified local time
+            * logging you want the filenames to use local time.
+            */
+        name = apr_psprintf(p, "%s.%" APR_TIME_T_FMT, name, apr_time_sec(log_time));
     }
 
     if (rv = apr_file_open(&fd, name, xfer_flags, xfer_perms, p), APR_SUCCESS != rv) {

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -197,6 +197,8 @@ static apr_time_t ap_get_quantized_time(rotated_log *rl, apr_time_t tm) {
  */
 static apr_status_t ap_lock_log(rotated_log *rl, request_rec *r) {
     apr_status_t rv = 0;
+    apr_file_t *ofd;
+    apr_pool_t *par, *np;
     apr_time_t logt = ap_get_quantized_time(rl, r->request_time);
     ap_log_error(APLOG_MARK, APLOG_DEBUG, rv, r->server, "New: %lu, old: %lu",
     (unsigned long) logt, (unsigned long) rl->logtime);
@@ -213,8 +215,7 @@ static apr_status_t ap_lock_log(rotated_log *rl, request_rec *r) {
      * for the mutex.
      */
     if (logt != rl->logtime) {
-        apr_file_t *ofd = rl->fd;
-        apr_pool_t *par, *np;
+        ofd = rl->fd;
         rl->logtime = logt;
         /* Create a new pool to provide storage for the new file.
          * Once we have the new file open we'll destroy the old

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -291,10 +291,17 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
                         "disabled log rotation for piped log %s.", name);
 
         if (pl = ap_open_piped_log(p, name + 1), NULL == pl) {
+            ap_log_error(APLOG_MARK, APLOG_CRIT, APR_EGENERAL, s,
+              "piped log file not loaded.");
            return NULL;
         }
 
-        rl->fd = ap_piped_log_write_fd(pl);
+        if (rl->fd = ap_piped_log_write_fd(pl), NULL == rl->fd) {
+            ap_log_error(APLOG_MARK, APLOG_CRIT, APR_EGENERAL, s,
+              "piped log file handle not loaded.");
+            return NULL;
+        }
+
         return rl;
     }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -120,12 +120,12 @@ static apr_file_t *ap_open_log(apr_pool_t *p, server_rec *s, const char *name, l
     else
     {
         /* Synthesize the log name using the specified time in seconds as a
-            * suffix.  We subtract the offset here because it was added when
-            * quantizing the time but we want the name to reflect the actual
-            * time when the log rotated. We don't reverse the local time
-            * adjustment because, presumably, if you've specified local time
-            * logging you want the filenames to use local time.
-            */
+         * suffix.  We subtract the offset here because it was added when
+         * quantizing the time but we want the name to reflect the actual
+         * time when the log rotated. We don't reverse the local time
+         * adjustment because, presumably, if you've specified local time
+         * logging you want the filenames to use local time.
+         */
         name = apr_psprintf(p, "%s.%" APR_TIME_T_FMT, name, apr_time_sec(log_time));
     }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -298,11 +298,6 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
         return rl;
     }
 
-    if (rv = apr_pool_create(&rl->pool, p), APR_SUCCESS != rv) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "can't make log rotation pool.");
-        return NULL;
-    }
-
 #if APR_HAS_THREADS
     {
         int mpm_threads;
@@ -333,6 +328,11 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
     if (NULL == rl->fname) {
         ap_log_error(APLOG_MARK, APLOG_ERR, APR_EBADPATH, s,
                         "invalid transfer log path %s.", name);
+        return NULL;
+    }
+
+    if (rv = apr_pool_create(&rl->pool, p), APR_SUCCESS != rv) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "can't make log rotation pool.");
         return NULL;
     }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -299,7 +299,7 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
     log_options *ls = ap_get_module_config(s->module_config, &log_rotate_module);
 
     rl = apr_palloc(p, sizeof(rotated_log));
-    rl->fname = apr_pstrdup(p, name);
+    rl->pool = NULL;
 
     if (rv = apr_pool_create(&rl->pool, p), APR_SUCCESS != rv) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "can't make log rotation pool.");
@@ -307,6 +307,7 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
     }
 
     rl->mutex.type = apr_anylock_none;
+    rl->fname = apr_pstrdup(p, name);
 
 #if APR_HAS_THREADS
     {

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -412,13 +412,13 @@ static void *merge_log_options(apr_pool_t *p, void *basev, void *addv) {
 /* map into the first apache */
 static int log_rotate_post_config( apr_pool_t * p, apr_pool_t * plog, apr_pool_t * ptemp, server_rec * s)
 {
-	ap_add_version_component(p, "mod_log_rotate/1.02");
-	return OK;
+    ap_add_version_component(p, "mod_log_rotate/1.02");
+    return OK;
 }
 
 static void log_rotate_register_hooks(apr_pool_t *p)
 {
-	ap_hook_post_config( log_rotate_post_config,   NULL, NULL, APR_HOOK_MIDDLE );
+    ap_hook_post_config( log_rotate_post_config,   NULL, NULL, APR_HOOK_MIDDLE );
 }
 
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -344,8 +344,8 @@ static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
     APR_OPTIONAL_FN_TYPE(ap_log_set_writer_init) *set_writer_init;
     APR_OPTIONAL_FN_TYPE(ap_log_set_writer)      *set_writer;
 
-    if (0 == flag) {
-        ls->enabled = 0;
+    ls->enabled = flag;
+    if (0 == ls->enabled) {
         return NULL;
     }
 
@@ -370,7 +370,6 @@ static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
 
     set_writer_init(ap_rotated_log_writer_init);
     set_writer(ap_rotated_log_writer);
-    ls->enabled = 1;
 
     return NULL;
 }

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -200,47 +200,51 @@ static apr_status_t ap_lock_log(rotated_log *rl, request_rec *r) {
     apr_time_t logt = ap_get_quantized_time(rl, r->request_time);
     ap_log_error(APLOG_MARK, APLOG_DEBUG, rv, r->server, "New: %lu, old: %lu",
     (unsigned long) logt, (unsigned long) rl->logtime);
+
     /* Decide if the quantized time has rolled over into a new slot. */
+    if (logt == rl->logtime) { return APR_SUCCESS; }
+
+    /* Get the mutex */
+    if (rv = APR_ANYLOCK_LOCK(&rl->mutex), APR_SUCCESS != rv) {
+        return rv;
+    }
+
+    /* Now check again in case someone else rotated the log while we waited
+     * for the mutex.
+     */
     if (logt != rl->logtime) {
-        /* Get the mutex */
-        if (rv = APR_ANYLOCK_LOCK(&rl->mutex), APR_SUCCESS != rv) {
+        apr_file_t *ofd = rl->fd;
+        apr_pool_t *par, *np;
+        rl->logtime = logt;
+        /* Create a new pool to provide storage for the new file.
+         * Once we have the new file open we'll destroy the old
+         * pool and make this one current.
+         */
+        par = apr_pool_parent_get(rl->pool);
+        if (rv = apr_pool_create(&np, par), APR_SUCCESS != rv) {
+            APR_ANYLOCK_UNLOCK(&rl->mutex);
             return rv;
         }
-        /* Now check again in case someone else rotated the log while we waited
-         * for the mutex.
+        /* Atomically replace the current log file because other
+         * threads, perhaps those responsible for a long lived
+         * request, won't have blocked on the mutex.
          */
-        if (logt != rl->logtime) {
-            apr_file_t *ofd = rl->fd;
-            apr_pool_t *par, *np;
-            rl->logtime = logt;
-            /* Create a new pool to provide storage for the new file.
-             * Once we have the new file open we'll destroy the old
-             * pool and make this one current.
-             */
-            par = apr_pool_parent_get(rl->pool);
-            if (rv = apr_pool_create(&np, par), APR_SUCCESS != rv) {
-                APR_ANYLOCK_UNLOCK(&rl->mutex);
-                return rv;
-            }
-            /* Atomically replace the current log file because other
-             * threads, perhaps those responsible for a long lived
-             * request, won't have blocked on the mutex.
-             */
-            if (rl->fd = ap_open_log(np, r->server, rl->fname, &rl->st, logt), NULL == rl->fd) {
-                /* Open failed so keep going with the old log... */
-                rl->fd = ofd;
-                /* ...and destroy the new pool. */
-                apr_pool_destroy(np);
-            } else {
-                /* Close the old log... */
-                ap_close_log(r->server, ofd);
-                /* ...and switch to the new pool. */
-                apr_pool_destroy(rl->pool);
-                rl->pool = np;
-            }
+        if (rl->fd = ap_open_log(np, r->server, rl->fname, &rl->st, logt), NULL == rl->fd) {
+            /* Open failed so keep going with the old log... */
+            rl->fd = ofd;
+            /* ...and destroy the new pool. */
+            apr_pool_destroy(np);
+        } else {
+            /* Close the old log... */
+            ap_close_log(r->server, ofd);
+            /* ...and switch to the new pool. */
+            apr_pool_destroy(rl->pool);
+            rl->pool = np;
         }
-        APR_ANYLOCK_UNLOCK(&rl->mutex);
     }
+
+    APR_ANYLOCK_UNLOCK(&rl->mutex);
+
     return APR_SUCCESS;
 }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -286,12 +286,10 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
     if (*name == '|') {
         piped_log *pl;
 
-        if (rl->st.enabled) {
-            /* Can't rotate a piped log */
-            rl->st.enabled = 0;
-            ap_log_error(APLOG_MARK, APLOG_WARNING, APR_SUCCESS, s,
-                            "disabled log rotation for piped log %s.", name);
-        }
+        /* Can't rotate a piped log */
+        rl->st.enabled = 0;
+        ap_log_error(APLOG_MARK, APLOG_WARNING, APR_SUCCESS, s,
+                        "disabled log rotation for piped log %s.", name);
 
         if (pl = ap_open_piped_log(p, name + 1), NULL == pl) {
            return NULL;

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -264,7 +264,13 @@ static apr_status_t ap_rotated_log_writer(request_rec *r, void *handle,
     apr_status_t rv = 0;
     rotated_log *rl = (rotated_log *) handle;
 
-    if (NULL != rl && NULL != rl->fd) {
+    if (NULL == rl) {
+        ap_log_rerror(APLOG_MARK, APLOG_CRIT, APR_EGENERAL, r,
+            "log rotation information not found.");
+        return APR_EGENERAL;
+    }
+
+    if (NULL != rl->fd) {
         if (rl->st.enabled) {
             if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
                 return rv;

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -101,6 +101,7 @@ static const char *ap_pstrftime(apr_pool_t *p, const char *format, apr_time_exp_
 static apr_file_t *ap_open_log(apr_pool_t *p, server_rec *s, const char *base, log_options *ls, apr_time_t tm) {
     apr_file_t *fd;
     apr_status_t rv;
+    apr_time_t log_time;
     const char *name = ap_server_root_relative(p, base);
 
     if (NULL == name) {
@@ -110,7 +111,7 @@ static apr_file_t *ap_open_log(apr_pool_t *p, server_rec *s, const char *base, l
     }
 
     if (ls->enabled) {
-        apr_time_t log_time = tm - ls->offset;
+        log_time = tm - ls->offset;
         if (strchr(base, '%') != NULL) {
             apr_time_exp_t e;
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -312,17 +312,17 @@ static void *ap_rotated_log_writer_init(apr_pool_t *p, server_rec *s, const char
      * duplicate functionality from mod_log_config. Note that we don't
      * support the buffered logging mode that mlc implements.
      */
-    if (*rl->fname == '|') {
+    if (*name == '|') {
         piped_log *pl;
 
         if (rl->st.enabled) {
             /* Can't rotate a piped log */
             rl->st.enabled = 0;
             ap_log_error(APLOG_MARK, APLOG_WARNING, APR_SUCCESS, s,
-                            "disabled log rotation for piped log %s.", rl->fname);
+                            "disabled log rotation for piped log %s.", name);
         }
 
-        if (pl = ap_open_piped_log(rl->pool, rl->fname + 1), NULL == pl) {
+        if (pl = ap_open_piped_log(p, name + 1), NULL == pl) {
            return NULL;
         }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -122,47 +122,45 @@ static apr_file_t *ap_open_log(apr_pool_t *p, server_rec *s, const char *base, l
 
         return ap_piped_log_write_fd(pl);
     }
-    else
-    {
-        apr_file_t *fd;
-        apr_status_t rv;
-        const char *name = ap_server_root_relative(p, base);
 
-        if (NULL == name) {
-            ap_log_error(APLOG_MARK, APLOG_ERR, APR_EBADPATH, s,
-                            "invalid transfer log path %s.", base);
-            return NULL;
-        }
+    apr_file_t *fd;
+    apr_status_t rv;
+    const char *name = ap_server_root_relative(p, base);
 
-        if (ls->enabled) {
-            apr_time_t log_time = tm - ls->offset;
-            if (strchr(base, '%') != NULL) {
-                apr_time_exp_t e;
-
-                apr_time_exp_gmt(&e, log_time);
-                name = ap_pstrftime(p, name, &e);
-            }
-            else
-            {
-                /* Synthesize the log name using the specified time in seconds as a
-                 * suffix.  We subtract the offset here because it was added when
-                 * quantizing the time but we want the name to reflect the actual
-                 * time when the log rotated. We don't reverse the local time
-                 * adjustment because, presumably, if you've specified local time
-                 * logging you want the filenames to use local time.
-                 */
-                name = apr_psprintf(p, "%s.%" APR_TIME_T_FMT, name, apr_time_sec(log_time));
-            }
-        }
-
-        if (rv = apr_file_open(&fd, name, xfer_flags, xfer_perms, p), APR_SUCCESS != rv) {
-            ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                            "could not open transfer log file %s.", name);
-            return NULL;
-        }
-
-        return fd;
+    if (NULL == name) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, APR_EBADPATH, s,
+                        "invalid transfer log path %s.", base);
+        return NULL;
     }
+
+    if (ls->enabled) {
+        apr_time_t log_time = tm - ls->offset;
+        if (strchr(base, '%') != NULL) {
+            apr_time_exp_t e;
+
+            apr_time_exp_gmt(&e, log_time);
+            name = ap_pstrftime(p, name, &e);
+        }
+        else
+        {
+            /* Synthesize the log name using the specified time in seconds as a
+                * suffix.  We subtract the offset here because it was added when
+                * quantizing the time but we want the name to reflect the actual
+                * time when the log rotated. We don't reverse the local time
+                * adjustment because, presumably, if you've specified local time
+                * logging you want the filenames to use local time.
+                */
+            name = apr_psprintf(p, "%s.%" APR_TIME_T_FMT, name, apr_time_sec(log_time));
+        }
+    }
+
+    if (rv = apr_file_open(&fd, name, xfer_flags, xfer_perms, p), APR_SUCCESS != rv) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
+                        "could not open transfer log file %s.", name);
+        return NULL;
+    }
+
+    return fd;
 }
 
 static apr_status_t ap_close_log(server_rec *s, apr_file_t *fd) {

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -252,9 +252,12 @@ static apr_status_t ap_rotated_log_writer(request_rec *r, void *handle,
         s += strl[i];
     }
 
-    if (RL_DISABLED != rl->st.enabled) {
-        if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
-            return rv;
+    if (RL_DISABLED == rl->st.enabled) {
+        return apr_file_write(rl->fd, str, &len);
+    }
+
+    if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv) {
+        return rv;
     }
 
     rv = apr_file_write(rl->fd, str, &len);

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -260,9 +260,11 @@ static apr_status_t ap_rotated_log_writer(request_rec *r, void *handle,
         return rv;
     }
 
-    rv = apr_file_write(rl->fd, str, &len);
+    if (rv = apr_file_write(rl->fd, str, &len), APR_SUCCESS != rv) {
+        return rv;
+    }
 
-    return rv;
+    return APR_SUCCESS;
 }
 
 /* Called my mod_log_config to initialise a log writer.

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -344,28 +344,27 @@ static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
     APR_OPTIONAL_FN_TYPE(ap_log_set_writer_init) *set_writer_init;
     APR_OPTIONAL_FN_TYPE(ap_log_set_writer)      *set_writer;
 
-    if (flag) {
-        /* Always hook the writer functions when we're enabled even if we've
-         * done it already. We can't unhook which means that once we've been
-         * enabled we become responsible for all transfer log output. Note that
-         * a subsequent BufferedLogs On in conf will clobber these hooks and
-         * disable us.
-         */
-        set_writer_init = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer_init);
-        set_writer      = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer);
-
-        if (NULL != set_writer_init && NULL != set_writer) {
-            set_writer_init(ap_rotated_log_writer_init);
-            set_writer(ap_rotated_log_writer);
-            ls->enabled = 1;
-        } else {
-            ap_log_error(APLOG_MARK, APLOG_ERR, APR_SUCCESS, cmd->server,
-                    "can't install log rotator - ap_log_set_writer not available");
-            ls->enabled = 0;
-        }
+    if (0 == flag) {
+        ls->enabled = 0;
+        return NULL;
     }
-    else
-    {
+
+    /* Always hook the writer functions when we're enabled even if we've
+     * done it already. We can't unhook which means that once we've been
+     * enabled we become responsible for all transfer log output. Note that
+     * a subsequent BufferedLogs On in conf will clobber these hooks and
+     * disable us.
+     */
+    set_writer_init = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer_init);
+    set_writer      = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer);
+
+    if (NULL != set_writer_init && NULL != set_writer) {
+        set_writer_init(ap_rotated_log_writer_init);
+        set_writer(ap_rotated_log_writer);
+        ls->enabled = 1;
+    } else {
+        ap_log_error(APLOG_MARK, APLOG_ERR, APR_SUCCESS, cmd->server,
+                "can't install log rotator - ap_log_set_writer not available");
         ls->enabled = 0;
     }
 

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -355,18 +355,22 @@ static const char *set_rotated_logs(cmd_parms *cmd, void *dummy, int flag) {
      * a subsequent BufferedLogs On in conf will clobber these hooks and
      * disable us.
      */
-    set_writer_init = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer_init);
-    set_writer      = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer);
-
-    if (NULL != set_writer_init && NULL != set_writer) {
-        set_writer_init(ap_rotated_log_writer_init);
-        set_writer(ap_rotated_log_writer);
-        ls->enabled = 1;
-    } else {
+    if (set_writer_init = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer_init), NULL == set_writer_init) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, APR_SUCCESS, cmd->server,
+                "can't install log rotator - ap_log_set_writer_init not available");
+        ls->enabled = 0;
+        return NULL;
+    }
+    if (set_writer = APR_RETRIEVE_OPTIONAL_FN(ap_log_set_writer), NULL == set_writer) {
         ap_log_error(APLOG_MARK, APLOG_ERR, APR_SUCCESS, cmd->server,
                 "can't install log rotator - ap_log_set_writer not available");
         ls->enabled = 0;
+        return NULL;
     }
+
+    set_writer_init(ap_rotated_log_writer_init);
+    set_writer(ap_rotated_log_writer);
+    ls->enabled = 1;
 
     return NULL;
 }

--- a/src/mod_log_rotate.c
+++ b/src/mod_log_rotate.c
@@ -242,26 +242,24 @@ static apr_status_t ap_rotated_log_writer(request_rec *r, void *handle,
         return APR_EGENERAL;
     }
 
-    if (NULL != rl->fd) {
-        str = apr_palloc(r->pool, len + 1);
-        for (i = 0, s = str; i < nelts; ++i) {
-            memcpy(s, strs[i], strl[i]);
-            s += strl[i];
-        }
-
-        if (RL_DISABLED != rl->st.enabled) {
-            if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
-                return rv;
-        }
-
-        rv = apr_file_write(rl->fd, str, &len);
-
-        return rv;
-    }
-    else
-    {
+    if (NULL == rl->fd)  {
         return APR_SUCCESS; /* Should we complain? */
     }
+
+    str = apr_palloc(r->pool, len + 1);
+    for (i = 0, s = str; i < nelts; ++i) {
+        memcpy(s, strs[i], strl[i]);
+        s += strl[i];
+    }
+
+    if (RL_DISABLED != rl->st.enabled) {
+        if (rv = ap_lock_log(rl, r), APR_SUCCESS != rv)
+            return rv;
+    }
+
+    rv = apr_file_write(rl->fd, str, &len);
+
+    return rv;
 }
 
 /* Called my mod_log_config to initialise a log writer.


### PR DESCRIPTION
A bunch of piece by piece refactoring to make things easier to reason about, and then 2 simple bug fixes.

First is a race condition where thread A can `apr_file_write` just as thread B calls `apr_file_close` on that file. This is because while the lock surround the `close` call, doesn't actually surround the `write` call.

Basic fix is to switch to a RWLock to minimize contention.

Second fix is that the parent process usually never logs, and so never rotates file handles, which basically means it functionally leaks the handle. On certain OSes this can prevent the file from being deleted, which somewhat defeats the point of log rotation.

Basic fix is just to close the file on the parent process and reopen it on first write if needed.

There's also one other significant change, which is to delay setting the callbacks until `ap_hook_open_logs`. This simplifies the takeover of responsibilities.